### PR TITLE
Update StaticLoggerBinder class in documentation

### DIFF
--- a/docs/hc5.md
+++ b/docs/hc5.md
@@ -78,11 +78,14 @@ import org.slf4j.spi.LoggerFactoryBinder
 
 class StaticLoggerBinder: LoggerFactoryBinder {
 
-    private val INSTANCE = StaticLoggerBinder()
+   companion object {
+      private val INSTANCE = StaticLoggerBinder()
 
-    fun getSingleton(): StaticLoggerBinder? {
-        return INSTANCE
-    }
+      @JvmStatic
+      fun getSingleton(): StaticLoggerBinder? {
+         return INSTANCE
+      }
+   }
 
     override fun getLoggerFactory(): ILoggerFactory? {
         return AndroidLoggerFactory.INSTANCE


### PR DESCRIPTION
Make getInstance() a static method as expected by caller.